### PR TITLE
unica: mods: tweaks: Simplify QHD display logic

### DIFF
--- a/unica/mods/tweaks/customize.sh
+++ b/unica/mods/tweaks/customize.sh
@@ -3,15 +3,13 @@ SKIPUNZIP=1
 WEBP_RES="2400"
 MP4_RES="1080:-1"
 
-if ! $SOURCE_HAS_QHD_DISPLAY; then
-    if $TARGET_HAS_QHD_DISPLAY; then
-        if [[ "$TARGET_PRODUCT_FIRST_API_LEVEL" -le 30 ]]; then
-            WEBP_RES="3200"
-        else
-            WEBP_RES="3088"
-        fi
-        MP4_RES="1440:-1"
+if $TARGET_HAS_QHD_DISPLAY; then
+    if [[ "$TARGET_PRODUCT_FIRST_API_LEVEL" -le 30 ]]; then
+        WEBP_RES="3200"
+    else
+        WEBP_RES="3088"
     fi
+    MP4_RES="1440:-1"
 fi
 
 echo "Resize wallpaper-res.apk"

--- a/unica/mods/tweaks/customize.sh
+++ b/unica/mods/tweaks/customize.sh
@@ -2,8 +2,17 @@ SKIPUNZIP=1
 
 WEBP_RES="2400"
 MP4_RES="1080:-1"
-[[ "$TARGET_CODENAME" == "b0q" ]] || [[ "$TARGET_CODENAME" == "dm3q" ]] && WEBP_RES="3088"
-[[ "$TARGET_CODENAME" == "b0q" ]] || [[ "$TARGET_CODENAME" == "dm3q" ]] && MP4_RES="1440:-1"
+
+if ! $SOURCE_HAS_QHD_DISPLAY; then
+    if $TARGET_HAS_QHD_DISPLAY; then
+        if [[ "$TARGET_PRODUCT_FIRST_API_LEVEL" -le 30 ]]; then
+            WEBP_RES="3200"
+        else
+            WEBP_RES="3088"
+        fi
+        MP4_RES="1440:-1"
+    fi
+fi
 
 echo "Resize wallpaper-res.apk"
 if [ ! -d "$APKTOOL_DIR/system/priv-app/wallpaper-res/wallpaper-res.apk" ]; then


### PR DESCRIPTION
This commit simplifies QHD display check for wallpaper-res patches and removes necessity of adding every QHD device one by one.