### PR TITLE
unica: mods: settings: add Knox logo visibility toggle

### DIFF
--- a/unica/mods/settings/smali/system/priv-app/BiometricSetting/BiometricSetting.apk/0002-Add-Knox-logo-visibility-toggle.patch
+++ b/unica/mods/settings/smali/system/priv-app/BiometricSetting/BiometricSetting.apk/0002-Add-Knox-logo-visibility-toggle.patch
@@ -1,0 +1,90 @@
+From 98eff3b6162b37f07fede0d7afac3ef2742290da Mon Sep 17 00:00:00 2001
+From: Nachito <104278947+naxitoo@users.noreply.github.com>
+Date: Sun, 16 Mar 2025 21:13:08 -0300
+Subject: [PATCH] Add Knox logo visibility toggle
+
+Add a toggle to control the visibility of the "Secured by Knox" logo displayed with the biometric prompt. If the toggle is not enabled, the logo is shown.
+
+Before:
+    public BiometricPromptGuiHelper(Context context, View view, PromptConfig promptConfig, UdfpsInfo udfpsInfo) {
+        this.mContext = context;
+        this.mBaseView = view;
+        this.mPromptConfig = promptConfig;
+        this.mUdfpsInfo = udfpsInfo;
+        this.mDisplayMetrics = Utils.getDisplayMetrics(context);
+        this.mScreenPortraitWidth = Utils.getDisplayWidth(this.mContext);
+        ImageView imageView = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_background);
+        if (!this.mPromptConfig.isManagedProfile() || this.mPromptConfig.isKnoxProfile()) {
+            imageView.setBackgroundColor(android.R.color.transparent);
+        } else {
+            Drawable drawable = new ResourceManager(this.mContext, "com.android.settings").getDrawable("work_challenge_background");
+            if (drawable != null) {
+                drawable.setColorFilter(this.mPromptConfig.getOrganizationColor(), PorterDuff.Mode.DARKEN);
+            }
+            imageView.setBackground(drawable);
+        }
+        ImageView imageView2 = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_knox_image);
+        if (imageView2 != null) {
+            imageView2.setVisibility(0);
+        }
+
+        // The rest of the code
+	}
+	
+After:
+    public BiometricPromptGuiHelper(Context context, View view, PromptConfig promptConfig, UdfpsInfo udfpsInfo) {
+        this.mContext = context;
+        this.mBaseView = view;
+        this.mPromptConfig = promptConfig;
+        this.mUdfpsInfo = udfpsInfo;
+        this.mDisplayMetrics = Utils.getDisplayMetrics(context);
+        this.mScreenPortraitWidth = Utils.getDisplayWidth(this.mContext);
+        ImageView imageView = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_background);
+        if (!this.mPromptConfig.isManagedProfile() || this.mPromptConfig.isKnoxProfile()) {
+            imageView.setBackgroundColor(android.R.color.transparent);
+        } else {
+            Drawable drawable = new ResourceManager(this.mContext, "com.android.settings").getDrawable("work_challenge_background");
+            if (drawable != null) {
+                drawable.setColorFilter(this.mPromptConfig.getOrganizationColor(), PorterDuff.Mode.DARKEN);
+            }
+            imageView.setBackground(drawable);
+        }
+        ImageView imageView2 = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_knox_image);
+        if (imageView2 != null && Settings.System.getInt(this.mContext.getContentResolver(), "unica_hide_bp_knox_logo", 0) == 0) {
+            imageView2.setVisibility(0);
+        }
+        
+		// The rest of the code
+	}
+---
+ .../setting/prompt/BiometricPromptGuiHelper.smali  | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/smali/com/samsung/android/biometrics/app/setting/prompt/BiometricPromptGuiHelper.smali b/smali/com/samsung/android/biometrics/app/setting/prompt/BiometricPromptGuiHelper.smali
+index 00e4c5d..6ce69ea 100644
+--- a/smali/com/samsung/android/biometrics/app/setting/prompt/BiometricPromptGuiHelper.smali
++++ b/smali/com/samsung/android/biometrics/app/setting/prompt/BiometricPromptGuiHelper.smali
+@@ -237,6 +237,20 @@
+ 
+     if-eqz p2, :cond_2
+ 
++    iget-object v1, p0, Lcom/samsung/android/biometrics/app/setting/prompt/BiometricPromptGuiHelper;->mContext:Landroid/content/Context;
++
++    invoke-virtual {v1}, Landroid/content/Context;->getContentResolver()Landroid/content/ContentResolver;
++
++    move-result-object v1
++
++    const-string v2, "unica_hide_bp_knox_logo"
++
++    invoke-static {v1, v2, p4}, Landroid/provider/Settings$System;->getInt(Landroid/content/ContentResolver;Ljava/lang/String;I)I
++
++    move-result v1
++
++    if-nez v1, :cond_2
++
+     invoke-virtual {p2, p4}, Landroid/widget/ImageView;->setVisibility(I)V
+ 
+     :cond_2
+-- 
+2.49.0
+

--- a/unica/mods/settings/smali/system/priv-app/SecSettings/SecSettings.apk/0008-Add-Knox-logo-visibility-toggle.patch
+++ b/unica/mods/settings/smali/system/priv-app/SecSettings/SecSettings.apk/0008-Add-Knox-logo-visibility-toggle.patch
@@ -1,0 +1,354 @@
+From f088bda80a874f656ddd1acd2dc70448ddc5a653 Mon Sep 17 00:00:00 2001
+From: Nachito <104278947+naxitoo@users.noreply.github.com>
+Date: Sun, 16 Mar 2025 20:21:15 -0300
+Subject: [PATCH] unica: mods: settings: add Knox logo visibility toggle
+
+Add a toggle to control the visibility of the "Secured by Knox" logo displayed with the biometric prompt. If the toggle is not enabled, the logo is shown.
+---
+ res/values/public.xml                         |  41 ++--
+ res/values/strings.xml                        |   1 +
+ res/xml/unica_settings.xml                    |   1 +
+ .../com/android/settings/R$string.smali       |  42 ++--
+ ...icPromptKnoxLogoPreferenceController.smali | 182 ++++++++++++++++++
+ 5 files changed, 227 insertions(+), 40 deletions(-)
+ create mode 100644 smali_classes4/io/mesalabs/unica/settings/BiometricPromptKnoxLogoPreferenceController.smali
+
+diff --git a/res/values/public.xml b/res/values/public.xml
+index 2e5da414e..a41c6e80a 100644
+--- a/res/values/public.xml
++++ b/res/values/public.xml
+@@ -32400,26 +32400,27 @@
+     <public type="string" name="unica_fod_anim_type_title" id="0x7f133464" />
+     <public type="string" name="unica_fod_anim_type_ultrasonic" id="0x7f133465" />
+     <public type="string" name="unica_games_spoof_title" id="0x7f133466" />
+-    <public type="string" name="unica_hide_dev_title" id="0x7f133467" />
+-    <public type="string" name="unica_max_refresh_rate_title" id="0x7f133468" />
+-    <public type="string" name="unica_native_blur_dialog_msg" id="0x7f133469" />
+-    <public type="string" name="unica_native_blur_dialog_negative" id="0x7f13346a" />
+-    <public type="string" name="unica_native_blur_dialog_positive" id="0x7f13346b" />
+-    <public type="string" name="unica_native_blur_dialog_title" id="0x7f13346c" />
+-    <public type="string" name="unica_native_blur_title" id="0x7f13346d" />
+-    <public type="string" name="unica_pif_checking" id="0x7f13346e" />
+-    <public type="string" name="unica_pif_error" id="0x7f13346f" />
+-    <public type="string" name="unica_pif_no_root" id="0x7f133470" />
+-    <public type="string" name="unica_pif_up_to_date" id="0x7f133471" />
+-    <public type="string" name="unica_pif_updated" id="0x7f133472" />
+-    <public type="string" name="unica_pif_version_title" id="0x7f133473" />
+-    <public type="string" name="unica_rom_version_title" id="0x7f133474" />
+-    <public type="string" name="unica_secure_ss_title" id="0x7f133475" />
+-    <public type="string" name="unica_settings_title" id="0x7f133476" />
+-    <public type="string" name="unica_spoof_settings_title" id="0x7f133477" />
+-    <public type="string" name="unica_ss_detection_title" id="0x7f133478" />
+-    <public type="string" name="unica_ui_settings_title" id="0x7f133479" />
+-    <public type="string" name="unica_updates_title" id="0x7f13347a" />
++    <public type="string" name="unica_hide_bp_knox_logo_title" id="0x7f133467" />
++    <public type="string" name="unica_hide_dev_title" id="0x7f133468" />
++    <public type="string" name="unica_max_refresh_rate_title" id="0x7f133469" />
++    <public type="string" name="unica_native_blur_dialog_msg" id="0x7f13346a" />
++    <public type="string" name="unica_native_blur_dialog_negative" id="0x7f13346b" />
++    <public type="string" name="unica_native_blur_dialog_positive" id="0x7f13346c" />
++    <public type="string" name="unica_native_blur_dialog_title" id="0x7f13346d" />
++    <public type="string" name="unica_native_blur_title" id="0x7f13346e" />
++    <public type="string" name="unica_pif_checking" id="0x7f13346f" />
++    <public type="string" name="unica_pif_error" id="0x7f133470" />
++    <public type="string" name="unica_pif_no_root" id="0x7f133471" />
++    <public type="string" name="unica_pif_up_to_date" id="0x7f133472" />
++    <public type="string" name="unica_pif_updated" id="0x7f133473" />
++    <public type="string" name="unica_pif_version_title" id="0x7f133474" />
++    <public type="string" name="unica_rom_version_title" id="0x7f133475" />
++    <public type="string" name="unica_secure_ss_title" id="0x7f133476" />
++    <public type="string" name="unica_settings_title" id="0x7f133477" />
++    <public type="string" name="unica_spoof_settings_title" id="0x7f133478" />
++    <public type="string" name="unica_ss_detection_title" id="0x7f133479" />
++    <public type="string" name="unica_ui_settings_title" id="0x7f13347a" />
++    <public type="string" name="unica_updates_title" id="0x7f13347b" />
+     <public type="style" name="Accessibility.Preference.A11ySeekBarPreference" id="0x7f140000" />
+     <public type="style" name="Accessibility.Preference.A11ySeekBarWithButtonsPreference" id="0x7f140001" />
+     <public type="style" name="Accessibility.Preference.SingleChoicePreference" id="0x7f140002" />
+diff --git a/res/values/strings.xml b/res/values/strings.xml
+index 22f2cc0ca..00a6fc7cb 100644
+--- a/res/values/strings.xml
++++ b/res/values/strings.xml
+@@ -14053,6 +14053,7 @@ In Camera, you can use the Top button to take pictures."</string>
+     <string name="unica_allow_downgrade_title">Allow application downgrade</string>
+     <string name="unica_allow_sdkbypass_title">Disable low target SDK block</string>
+     <string name="unica_asks_title">Disable ASKS</string>
++    <string name="unica_hide_bp_knox_logo_title">Hide \"Secured by Knox\" logo in biometric prompt</string>
+     <string name="unica_boot_sound_title">Play power on sound effect</string>
+     <string name="unica_device_name_title">Device name</string>
+     <string name="unica_extra_settings_title">Extra settings</string>
+diff --git a/res/xml/unica_settings.xml b/res/xml/unica_settings.xml
+index c33fa6b5d..8e1e815b7 100644
+--- a/res/xml/unica_settings.xml
++++ b/res/xml/unica_settings.xml
+@@ -11,6 +11,7 @@
+         <SecSwitchPreference android:title="@string/unica_native_blur_title" android:key="unica_native_blur" settings:controller="io.mesalabs.unica.settings.LiveBlurPreferenceController" />
+         <SecDropDownPreference android:title="@string/unica_fod_anim_type_title" android:key="unica_fod_anim_type" settings:controller="io.mesalabs.unica.settings.FODAnimationTypePreferenceController" settings:useSimpleSummaryProvider="true" />
+         <SecSwitchPreference android:title="@string/unica_max_refresh_rate_title" android:key="unica_max_refresh_rate" settings:controller="io.mesalabs.unica.settings.ForceMaxRefreshRatePreferenceController" />
++        <SecSwitchPreference android:title="@string/unica_hide_bp_knox_logo_title" android:key="unica_hide_bp_knox_logo" settings:controller="io.mesalabs.unica.settings.BiometricPromptKnoxLogoPreferenceController" />
+     </SecPreferenceCategory>
+     <SecPreferenceCategory android:title="@string/unica_spoof_settings_title">
+         <SecSwitchPreference android:title="@string/unica_games_spoof_title" android:key="unica_games_spoof" settings:controller="io.mesalabs.unica.settings.GamesPropsPreferenceController" />
+diff --git a/smali_classes2/com/android/settings/R$string.smali b/smali_classes2/com/android/settings/R$string.smali
+index ba0f5146d..8a454d260 100644
+--- a/smali_classes2/com/android/settings/R$string.smali
++++ b/smali_classes2/com/android/settings/R$string.smali
+@@ -10692,45 +10692,47 @@
+ 
+ .field public static final unica_games_spoof_title:I = 0x7f133466
+ 
+-.field public static final unica_hide_dev_title:I = 0x7f133467
++.field public static final unica_hide_bp_knox_logo_title:I = 0x7f133467
+ 
+-.field public static final unica_max_refresh_rate_title:I = 0x7f133468
++.field public static final unica_hide_dev_title:I = 0x7f133468
+ 
+-.field public static final unica_native_blur_dialog_msg:I = 0x7f133469
++.field public static final unica_max_refresh_rate_title:I = 0x7f133469
+ 
+-.field public static final unica_native_blur_dialog_negative:I = 0x7f13346a
++.field public static final unica_native_blur_dialog_msg:I = 0x7f13346a
+ 
+-.field public static final unica_native_blur_dialog_positive:I = 0x7f13346b
++.field public static final unica_native_blur_dialog_negative:I = 0x7f13346b
+ 
+-.field public static final unica_native_blur_dialog_title:I = 0x7f13346c
++.field public static final unica_native_blur_dialog_positive:I = 0x7f13346c
+ 
+-.field public static final unica_native_blur_title:I = 0x7f13346d
++.field public static final unica_native_blur_dialog_title:I = 0x7f13346d
+ 
+-.field public static final unica_pif_checking:I = 0x7f13346e
++.field public static final unica_native_blur_title:I = 0x7f13346e
+ 
+-.field public static final unica_pif_error:I = 0x7f13346f
++.field public static final unica_pif_checking:I = 0x7f13346f
+ 
+-.field public static final unica_pif_no_root:I = 0x7f133470
++.field public static final unica_pif_error:I = 0x7f133470
+ 
+-.field public static final unica_pif_up_to_date:I = 0x7f133471
++.field public static final unica_pif_no_root:I = 0x7f133471
+ 
+-.field public static final unica_pif_updated:I = 0x7f133472
++.field public static final unica_pif_up_to_date:I = 0x7f133472
+ 
+-.field public static final unica_pif_version_title:I = 0x7f133473
++.field public static final unica_pif_updated:I = 0x7f133473
+ 
+-.field public static final unica_rom_version_title:I = 0x7f133474
++.field public static final unica_pif_version_title:I = 0x7f133474
+ 
+-.field public static final unica_secure_ss_title:I = 0x7f133475
++.field public static final unica_rom_version_title:I = 0x7f133475
+ 
+-.field public static final unica_settings_title:I = 0x7f133476
++.field public static final unica_secure_ss_title:I = 0x7f133476
+ 
+-.field public static final unica_spoof_settings_title:I = 0x7f133477
++.field public static final unica_settings_title:I = 0x7f133477
+ 
+-.field public static final unica_ss_detection_title:I = 0x7f133478
++.field public static final unica_spoof_settings_title:I = 0x7f133478
+ 
+-.field public static final unica_ui_settings_title:I = 0x7f133479
++.field public static final unica_ss_detection_title:I = 0x7f133479
+ 
+-.field public static final unica_updates_title:I = 0x7f13347a
++.field public static final unica_ui_settings_title:I = 0x7f13347a
++
++.field public static final unica_updates_title:I = 0x7f13347b
+ 
+ .field public static final uninstall:I = 0x7f132c1e
+ 
+diff --git a/smali_classes4/io/mesalabs/unica/settings/BiometricPromptKnoxLogoPreferenceController.smali b/smali_classes4/io/mesalabs/unica/settings/BiometricPromptKnoxLogoPreferenceController.smali
+new file mode 100644
+index 000000000..9cdcf7bfd
+--- /dev/null
++++ b/smali_classes4/io/mesalabs/unica/settings/BiometricPromptKnoxLogoPreferenceController.smali
+@@ -0,0 +1,182 @@
++.class public Lio/mesalabs/unica/settings/BiometricPromptKnoxLogoPreferenceController;
++.super Lcom/android/settings/core/TogglePreferenceController;
++.source "BiometricPromptKnoxLogoPreferenceController.java"
++
++
++# direct methods
++.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;)V
++    .locals 0
++
++    invoke-direct {p0, p1, p2}, Lcom/android/settings/core/TogglePreferenceController;-><init>(Landroid/content/Context;Ljava/lang/String;)V
++
++    return-void
++.end method
++
++
++# virtual methods
++.method public getAvailabilityStatus()I
++    .locals 0
++
++    const/4 p0, 0x0
++
++    return p0
++.end method
++
++.method public bridge synthetic getBackgroundWorkerClass()Ljava/lang/Class;
++    .locals 0
++
++    invoke-super {p0}, Lcom/android/settings/slices/Sliceable;->getBackgroundWorkerClass()Ljava/lang/Class;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public bridge synthetic getBackupKeys()Ljava/util/List;
++    .locals 0
++
++    invoke-super {p0}, Lcom/samsung/android/settings/cube/Controllable;->getBackupKeys()Ljava/util/List;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public bridge synthetic getIntentFilter()Landroid/content/IntentFilter;
++    .locals 0
++
++    invoke-super {p0}, Lcom/android/settings/slices/Sliceable;->getIntentFilter()Landroid/content/IntentFilter;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public bridge synthetic getLaunchIntent()Landroid/content/Intent;
++    .locals 0
++
++    invoke-super {p0}, Lcom/samsung/android/settings/cube/Controllable;->getLaunchIntent()Landroid/content/Intent;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public getSliceHighlightMenuRes()I
++    .locals 0
++
++    sget p0, Lcom/android/settings/R$string;->menu_key_unica_settings:I
++
++    return p0
++.end method
++
++.method public bridge synthetic getStatusText()Ljava/lang/String;
++    .locals 0
++
++    invoke-super {p0}, Lcom/samsung/android/settings/cube/Controllable;->getStatusText()Ljava/lang/String;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public bridge synthetic hasAsyncUpdate()Z
++    .locals 0
++
++    invoke-super {p0}, Lcom/android/settings/slices/Sliceable;->hasAsyncUpdate()Z
++
++    move-result p0
++
++    return p0
++.end method
++
++.method public bridge synthetic ignoreUserInteraction()V
++    .locals 0
++
++    invoke-super {p0}, Lcom/samsung/android/settings/cube/Controllable;->ignoreUserInteraction()V
++
++    return-void
++.end method
++
++.method public isChecked()Z
++    .locals 2
++
++    iget-object p0, p0, Lcom/android/settingslib/core/AbstractPreferenceController;->mContext:Landroid/content/Context;
++
++    invoke-virtual {p0}, Landroid/content/Context;->getContentResolver()Landroid/content/ContentResolver;
++
++    move-result-object p0
++
++    const-string v0, "unica_hide_bp_knox_logo"
++
++    const/4 v1, 0x0
++
++    invoke-static {p0, v0, v1}, Landroid/provider/Settings$System;->getInt(Landroid/content/ContentResolver;Ljava/lang/String;I)I
++
++    move-result p0
++
++    const/4 v0, 0x1
++
++    if-ne p0, v0, :cond_0
++
++    move v1, v0
++
++    :cond_0
++    return v1
++.end method
++
++.method public isControllable()Z
++    .locals 0
++
++    const/4 p0, 0x1
++
++    return p0
++.end method
++
++.method public bridge synthetic needUserInteraction(Ljava/lang/Object;)Lcom/samsung/android/settings/cube/Controllable$ControllableType;
++    .locals 0
++
++    invoke-super {p0, p1}, Lcom/samsung/android/settings/cube/Controllable;->needUserInteraction(Ljava/lang/Object;)Lcom/samsung/android/settings/cube/Controllable$ControllableType;
++
++    move-result-object p0
++
++    return-object p0
++.end method
++
++.method public bridge synthetic runDefaultAction()Z
++    .locals 0
++
++    invoke-super {p0}, Lcom/samsung/android/settings/cube/Controllable;->runDefaultAction()Z
++
++    move-result p0
++
++    return p0
++.end method
++
++.method public setChecked(Z)Z
++    .locals 1
++
++    iget-object p0, p0, Lcom/android/settingslib/core/AbstractPreferenceController;->mContext:Landroid/content/Context;
++
++    invoke-virtual {p0}, Landroid/content/Context;->getContentResolver()Landroid/content/ContentResolver;
++
++    move-result-object p0
++
++    const-string v0, "unica_hide_bp_knox_logo"
++
++    invoke-static {p0, v0, p1}, Landroid/provider/Settings$System;->putInt(Landroid/content/ContentResolver;Ljava/lang/String;I)Z
++
++    move-result p0
++
++    return p0
++.end method
++
++.method public bridge synthetic useDynamicSliceSummary()Z
++    .locals 0
++
++    invoke-super {p0}, Lcom/android/settings/slices/Sliceable;->useDynamicSliceSummary()Z
++
++    move-result p0
++
++    return p0
++.end method
+-- 
+2.49.0
+


### PR DESCRIPTION
### Add a toggle to control the visibility of the "Secured by Knox" logo displayed with the biometric prompt. If the toggle is not enabled, the logo is shown.

#### Before:
```java
    public BiometricPromptGuiHelper(Context context, View view, PromptConfig promptConfig, UdfpsInfo udfpsInfo) {
        this.mContext = context;
        this.mBaseView = view;
        this.mPromptConfig = promptConfig;
        this.mUdfpsInfo = udfpsInfo;
        this.mDisplayMetrics = Utils.getDisplayMetrics(context);
        this.mScreenPortraitWidth = Utils.getDisplayWidth(this.mContext);
        ImageView imageView = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_background);
        if (!this.mPromptConfig.isManagedProfile() || this.mPromptConfig.isKnoxProfile()) {
            imageView.setBackgroundColor(android.R.color.transparent);
        } else {
            Drawable drawable = new ResourceManager(this.mContext, "com.android.settings").getDrawable("work_challenge_background");
            if (drawable != null) {
                drawable.setColorFilter(this.mPromptConfig.getOrganizationColor(), PorterDuff.Mode.DARKEN);
            }
            imageView.setBackground(drawable);
        }
        ImageView imageView2 = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_knox_image);
        if (imageView2 != null) {
            imageView2.setVisibility(0);
        }

         // The rest of the code
    }
```

#### After:
```java
    public BiometricPromptGuiHelper(Context context, View view, PromptConfig promptConfig, UdfpsInfo udfpsInfo) {
        this.mContext = context;
        this.mBaseView = view;
        this.mPromptConfig = promptConfig;
        this.mUdfpsInfo = udfpsInfo;
        this.mDisplayMetrics = Utils.getDisplayMetrics(context);
        this.mScreenPortraitWidth = Utils.getDisplayWidth(this.mContext);
        ImageView imageView = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_background);
        if (!this.mPromptConfig.isManagedProfile() || this.mPromptConfig.isKnoxProfile()) {
            imageView.setBackgroundColor(android.R.color.transparent);
        } else {
            Drawable drawable = new ResourceManager(this.mContext, "com.android.settings").getDrawable("work_challenge_background");
            if (drawable != null) {
                drawable.setColorFilter(this.mPromptConfig.getOrganizationColor(), PorterDuff.Mode.DARKEN);
            }
            imageView.setBackground(drawable);
        }
        ImageView imageView2 = (ImageView) this.mBaseView.findViewById(R.id.id_prompt_knox_image);
        if (imageView2 != null && Settings.System.getInt(this.mContext.getContentResolver(), "unica_hide_bp_knox_logo", 0) == 0) {
            imageView2.setVisibility(0);
        }

        // The rest of the code
    }
```