### PR TITLE
A71: Ship PrimeKernel

### DIFF
--- a/target/a71/patches/primekernel/customize.sh
+++ b/target/a71/patches/primekernel/customize.sh
@@ -1,0 +1,16 @@
+SKIPUNZIP=1
+
+# [
+KERNEL_REPO="https://github.com/pascua28/android_kernel_samsung_sm7150/releases/download/upstream"
+
+REPLACE_KERNEL_BINARIES()
+ {
+     [ -f "$WORK_DIR/kernel/boot.img" ] && rm -rf "$WORK_DIR/kernel/boot.img"
+     echo "Downloading boot.img"
+     curl -L -s -o "$WORK_DIR/kernel/boot.img" "$KERNEL_REPO/boot.img"
+ }
+# ]
+
+REPLACE_KERNEL_BINARIES
+
+

--- a/target/a71/patches/primekernel/module.prop
+++ b/target/a71/patches/primekernel/module.prop
@@ -1,0 +1,4 @@
+id=prime
+name=PrimeKernel
+author=pascua28
+description=PrimeKernel as default ROM kernel.


### PR DESCRIPTION
The kernel is based on this source: https://github.com/pascua28/android_kernel_samsung_sm7150/tree/upstream-rel

This is a kernel with minimal changes on top of the stock kernel.

- Latest Android common kernel merged (Linux 4.14.336)
- Latest code linaro tag merged
- BPF changes needed by Android 14
- EROFS support
- UFFD for garbage collector
- BPF backports needed by Android 15