### PR TITLE
unica: patches: legacy: fix sec_pass file label check

### DIFF
--- a/unica/patches/legacy/customize.sh
+++ b/unica/patches/legacy/customize.sh
@@ -256,7 +256,7 @@ fi
 
 # Ensure PASS support (pre-API 35)
 if [ "$TARGET_PLATFORM_SDK_VERSION" -lt "35" ]; then
-    if ! grep -q "sec_pass_data_file" "$WORK_DIR/vendor/etc/selinux/vendor_sepolicy.cil"; then
+    if ! grep -q "sec_pass_data_file" "$WORK_DIR/vendor/etc/selinux/vendor_file_contexts"; then
         PATCHED=true
         SMALI_PATCH "system" "system/framework/services.jar" \
             "smali/com/android/server/StorageManagerService.smali" "return" \


### PR DESCRIPTION
`sec_pass_data_file` label may be found in `/vendor/etc/selinux/vendor_sepolicy.cil` but not in `/vendor/etc/selinux/vendor_file_contexts`. As a result, `/data/sec_pass/` is never created while `isPassSupport()` still returns true.
Avoid this false positive by checking at `/vendor/etc/selinux/vendor_file_contexts`