### PR TITLE
unica: mods: settings: abstract fragment validation

### DIFF
--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaExtraSettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaExtraSettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaExtraSettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaHMASettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaHMASettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaHMASettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaHideDevSettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaHideDevSettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaHideDevSettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaSettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaSettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaSettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaSpoofSettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaSpoofSettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaSpoofSettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaUISettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/com/android/settings/Settings$UnicaUISettingsActivity.smali
@@ -1,5 +1,5 @@
 .class public Lcom/android/settings/Settings$UnicaUISettingsActivity;
-.super Lcom/android/settings/SettingsActivity;
+.super Lio/mesalabs/unica/UnicaBaseSettingsActivity;
 .source "Settings.java"
 
 
@@ -7,7 +7,7 @@
 .method public constructor <init>()V
     .locals 0
 
-    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+    invoke-direct {p0}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;-><init>()V
 
     return-void
 .end method

--- a/unica/mods/settings/SecSettings.apk/smali_classes4/io/mesalabs/unica/UnicaBaseSettingsActivity.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/io/mesalabs/unica/UnicaBaseSettingsActivity.smali
@@ -1,0 +1,83 @@
+.class public abstract Lio/mesalabs/unica/UnicaBaseSettingsActivity;
+.super Lcom/android/settings/SettingsActivity;
+.source "UnicaBaseSettingsActivity.java"
+
+
+# direct methods
+.method public constructor <init>()V
+    .locals 0
+
+    invoke-direct {p0}, Lcom/android/settings/SettingsActivity;-><init>()V
+
+    return-void
+.end method
+
+.method private isUnicaFragment(Ljava/lang/String;)Z
+    .locals 3
+
+    if-nez p1, :cond_0
+
+    const/4 p0, 0x0
+
+    return p0
+
+    :cond_0
+    const-string v0, "io.mesalabs.unica.settings"
+
+    invoke-virtual {p1, v0}, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+
+    move-result v0
+
+    const/16 v1, 0x2e
+
+    invoke-virtual {p1, v1}, Ljava/lang/String;->lastIndexOf(I)I
+
+    move-result v1
+
+    add-int/lit8 v1, v1, 0x1
+
+    invoke-virtual {p1, v1}, Ljava/lang/String;->substring(I)Ljava/lang/String;
+
+    move-result-object p1
+
+    if-eqz v0, :cond_1
+
+    invoke-virtual {p0}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object p0
+
+    invoke-virtual {p0}, Ljava/lang/Class;->getSimpleName()Ljava/lang/String;
+
+    move-result-object p0
+
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    const-string v2, "Valid UN1CA fragment: "
+
+    invoke-direct {v1, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v1, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p1
+
+    invoke-static {p0, p1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    :cond_1
+    return v0
+.end method
+
+
+# virtual methods
+.method public final isValidFragment(Ljava/lang/String;)Z
+    .locals 0
+
+    invoke-direct {p0, p1}, Lio/mesalabs/unica/UnicaBaseSettingsActivity;->isUnicaFragment(Ljava/lang/String;)Z
+
+    move-result p0
+
+    return p0
+.end method

--- a/unica/mods/settings/customize.sh
+++ b/unica/mods/settings/customize.sh
@@ -69,52 +69,6 @@ while IFS= read -r f; do
     fi
 done < <(find "$MODPATH/SecSettings.apk" -type f)
 
-# Mark UN1CA Settings fragments as "valid"
-LOG "- Patching \"smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali\" in /system/system/priv-app/SecSettings.apk"
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v159}, [Ljava/lang/String;' \
-    '    const-string v160, "io.mesalabs.unica.settings.UnicaSettingsFragment"\n\n    filled-new-array/range {v1 .. v160}, [Ljava/lang/String;' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v160}, [Ljava/lang/String;' \
-    '    const-string v161, "io.mesalabs.unica.settings.extra.ExtraSettingsFragment"\n\n    filled-new-array/range {v1 .. v161}, [Ljava/lang/String;' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v161}, [Ljava/lang/String;' \
-    '    const-string v162, "io.mesalabs.unica.settings.hma.HideMyApplistFragment"\n\n    filled-new-array/range {v1 .. v162}, [Ljava/lang/String;' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v162}, [Ljava/lang/String;' \
-    '    const-string v163, "io.mesalabs.unica.settings.spoof.HideDeveloperStatusFragment"\n\n    filled-new-array/range {v1 .. v163}, [Ljava/lang/String;' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v163}, [Ljava/lang/String;' \
-    '    const-string v164, "io.mesalabs.unica.settings.spoof.SpoofSettingsFragment"\n\n    filled-new-array/range {v1 .. v164}, [Ljava/lang/String;' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/core/gateway/SettingsGateway.smali" "replace" \
-    '<clinit>()V' \
-    'filled-new-array/range {v1 .. v164}, [Ljava/lang/String;' \
-    '    const-string v165, "io.mesalabs.unica.settings.ui.UISettingsFragment"\n\n    filled-new-array/range {v1 .. v165}, [Ljava/lang/String;' \
-    > /dev/null
-LOG "- Patching \"smali_classes2/com/android/settings/SettingsActivity.smali\" in /system/system/priv-app/SecSettings.apk"
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali_classes2/com/android/settings/SettingsActivity.smali" "replace" \
-    'isValidFragment(Ljava/lang/String;)Z' \
-    'const/16 v2, 0x9f' \
-    'const/16 v2, 0xa5' \
-    > /dev/null
-
 # Add UN1CA Settings SearchIndexDataProvider(s)
 LOG "- Patching \"smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali\" in /system/system/priv-app/SecSettings.apk"
 SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \


### PR DESCRIPTION
### Description
This PR introduces a more robust way to validate UN1CA Settings fragments, moving away from fragile build-time Smali patching to a cleaner, inheritance-based approach.

### Motivation
Previously, adding a new fragment required two separate patches on every firmware rebase: adding the fragment class name to `SettingsGateway.SAMSUNG_ENTRY_FRAGMENTS` and updating the hardcoded array size in `SettingsActivity.isValidFragment` to match. Both values depend on the firmware's existing array layout and break on every rebase when Samsung changes it.

### Changes
* **Introduced `UnicaBaseSettingsActivity`**: A new abstract base class that overrides `isValidFragment`.
* **Dynamic Validation**: The validation now automatically accepts any fragment under the `io.mesalabs.unica.settings` package prefix.
* **Refactor**: Updated all `UnicaXXXXActivity` classes to inherit from the new base class.
* **Cleanup**: Removed the legacy logic from `customize.sh` that handled manual Smali patching.

**Base Class Implementation:**
```java
public abstract class UnicaBaseSettingsActivity extends SettingsActivity {
    @Override
    public final boolean isValidFragment(String fqcn) {
        return isUnicaFragment(fqcn);
    }

    private boolean isUnicaFragment(String fqcn) {
        if (fqcn == null) {
            return false;
        }

        boolean valid = fqcn.startsWith("io.mesalabs.unica.settings");
        String simpleName = fqcn.substring(fqcn.lastIndexOf('.') + 1);

        if (valid) {
            Log.d(this.getClass().getSimpleName(), "Valid UN1CA fragment: " + simpleName);
        }

        return valid;
    }
}
```

**Refactored Activity:**
```java
public class UnicaXXXXActivity extends UnicaBaseSettingsActivity { }
```

### Reference
This approach mirrors how Samsung handles specific category activities (e.g., `ConnectionsSettingsActivity`), validating the fragment name directly:

```java
public class ConnectionsSettingsActivity extends SettingsActivity {
    @Override // com.android.settings.SettingsActivity
    public final boolean isValidFragment(String str) {
        if (!TextUtils.equals("com.samsung.android.settings.connection.ConnectionsSettings", str)) {
            return false;
        }
        Log.i("ConnectionsSettingsActivity", "Connectionsettings isValidFragment");
        return true;
    }
}
```

### Logs
```zsh
# Testing validation and navigation
❯ adb logcat '*:D' -v color,brief | grep -iE 'Invalid fragment for this activity|Valid UN1CA fragment|Launching fragment'
```
```logcat
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.UnicaSettingsFragment
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.ui.UISettingsFragment
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.spoof.SpoofSettingsFragment
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.hma.HideMyApplistFragment
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.spoof.HideDeveloperStatusFragment
D/SubSettings(13368): Launching fragment io.mesalabs.unica.settings.extra.ExtraSettingsFragment
D/Settings$UnicaSettingsActivity(13368): Valid UN1CA fragment: UnicaSettingsFragment
D/Settings$UnicaUISettingsActivity(13368): Valid UN1CA fragment: UISettingsFragment
D/Settings$UnicaSpoofSettingsActivity(13368): Valid UN1CA fragment: SpoofSettingsFragment
D/Settings$UnicaHMASettingsActivity(13368): Valid UN1CA fragment: HideMyApplistFragment
D/Settings$UnicaHideDevSettingsActivity(13368): Valid UN1CA fragment: HideDeveloperStatusFragment
D/Settings$UnicaExtraSettingsActivity(13368): Valid UN1CA fragment: ExtraSettingsFragment
```

### Benefits
* **Zero-Maintenance**: Adding new fragments in the future requires no build system changes or manual patching.
* **Stability**: Removes the risk of index/register mismatches during firmware base updates.
* **Improved Debugging**: Added logging to easily verify fragment validation.

> [!NOTE]
> This PR specifically targets the validation of UN1CA fragments launched via their own activities. Internal navigation remains handled by `SubSettings`, whose `isValidFragment()` always returns `true`:
>
> ```java
> public class SubSettings extends SettingsActivity {
>     @Override // com.android.settings.SettingsActivity
>     public boolean isValidFragment(String str) {
>         Log.d("SubSettings", "Launching fragment ".concat(str));
>         return true;
>     }
>
>     // ...
> }
> ```