### PR TITLE
unica: patches: nfc: Add NXP_PN553 support

### DIFF
--- a/unica/patches/nfc/customize.sh
+++ b/unica/patches/nfc/customize.sh
@@ -24,7 +24,7 @@ if [ -f "$FW_DIR/$TARGET_FIRMWARE_PATH/system/system/etc/libnfc-nci-STM_ST21.con
 fi
 
 if [ "$(GET_PROP "vendor" "ro.vendor.nfc.feature.chipname")" ] && \
-        ! [[ "$(GET_PROP "vendor" "ro.vendor.nfc.feature.chipname")" =~ NXP_SN100U|SLSI|STM_ST21 ]]; then
+        ! [[ "$(GET_PROP "vendor" "ro.vendor.nfc.feature.chipname")" =~ NXP_PN553|NXP_SN100U|SLSI|STM_ST21 ]]; then
     ABORT "Unknown NFC chip name: $(GET_PROP "vendor" "ro.vendor.nfc.feature.chipname")"
 fi
 
@@ -117,6 +117,13 @@ elif [ -f "$FW_DIR/$TARGET_FIRMWARE_PATH/system/system/lib64/libnfc_sec_jni.so" 
     else
         ADD_TO_WORK_DIR "r11sxxx" "system" "system/lib64/libnfc_sec_jni.so" 0 0 644 "u:object_r:system_lib_file:s0"
     fi
+fi
+
+# SEC_PRODUCT_FEATURE_NFC_CHIP_NAME:=NXP_PN553
+if [ -f "$FW_DIR/$TARGET_FIRMWARE_PATH/system/system/lib64/libnfc_nxppn_jni.so" ]; then
+    ADD_TO_WORK_DIR "$SOURCE_FIRMWARE" "system" "system/lib64/libnfc_nci_jni.so" 0 0 644 "u:object_r:system_lib_file:s0"
+    ADD_TO_WORK_DIR "$SOURCE_FIRMWARE" "system" "system/lib64/libnfc_prop_extn.so" 0 0 644 "u:object_r:system_lib_file:s0"
+    ADD_TO_WORK_DIR "$SOURCE_FIRMWARE" "system" "system/lib64/libnfc_vendor_extn.so" 0 0 644 "u:object_r:system_lib_file:s0"
 fi
 
 unset TARGET_FIRMWARE_PATH


### PR DESCRIPTION
Used by devices like A71 which use libnfc-nxppn