### PR TITLE
fixup! scripts: build_incremental_ota_zip: ignore diff for identical images

### DIFF
--- a/scripts/internal/build_incremental_ota_zip.sh
+++ b/scripts/internal/build_incremental_ota_zip.sh
@@ -486,7 +486,7 @@ for p in $PARTITIONS_LIST; do
     fi
 
     if [ -f "$TMP_DIR/source/$p.img" ]; then
-        if [[ "$(sha1sum "$TMP_DIR/source/$p.img")" != "$(sha1sum "$TMP_DIR/target/$p.img")" ]]; then
+        if [[ "$(sha1sum "$TMP_DIR/source/$p.img" | cut " " -f1)" != "$(sha1sum "$TMP_DIR/target/$p.img" | cut " " -f1)" ]]; then
             _CHECK_NON_EMPTY_PARAM "TARGET_CACHE_PARTITION_SIZE" "${TARGET_CACHE_PARTITION_SIZE//none/}" || exit 1
             LOG "- Generating $p.img block diff"
             EVAL "img2sdat -o \"$TMP_DIR\" -c \"$TARGET_CACHE_PARTITION_SIZE\" --src-image \"$TMP_DIR/source/$p.img\" --src-block-map \"$TMP_DIR/source/$p.map\" --tgt-block-map \"$TMP_DIR/target/$p.map\" \"$TMP_DIR/target/$p.img\"" || exit 1


### PR DESCRIPTION
* `sha1sum` also prints path to file in "$2". In our case that would make the condition always false, because of different directories (source vs target). Print "$1" only aka the hash to fix the condition.

- [x] Test and mark as "Ready for review"