### PR TITLE
unica: mods: settings: spoof SEM_FIRST_SDK_INT to 35 for Samsung Camera

### DIFF
--- a/unica/mods/settings/smali/system/framework/framework.jar/0002-Introduce-SamsungPropsHooks.patch
+++ b/unica/mods/settings/smali/system/framework/framework.jar/0002-Introduce-SamsungPropsHooks.patch
@@ -1,26 +1,28 @@
-From d87232c9d922bd3964f68d3ec12b37a4ce09f224 Mon Sep 17 00:00:00 2001
+From f299cbce0b640455fa7013bbac7f3b7c2eecc06d Mon Sep 17 00:00:00 2001
 From: Salvo Giangreco <giangrecosalvo9@gmail.com>
 Date: Fri, 24 Oct 2025 11:59:09 +0200
 Subject: [PATCH] Introduce SamsungPropsHooks
 
 UN1CA: this patch is not complete! Please check unica/mods/settings/customize.sh for more info.
 ---
- .../io/mesalabs/unica/SamsungPropsHooks.smali | 333 ++++++++++++++++++
- 1 file changed, 333 insertions(+)
+ .../io/mesalabs/unica/SamsungPropsHooks.smali | 437 ++++++++++++++++++
+ 1 file changed, 437 insertions(+)
  create mode 100644 smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
 
 diff --git a/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali b/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
 new file mode 100644
-index 00000000..0dd7320d
+index 00000000..0c4ac7b4
 --- /dev/null
 +++ b/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
-@@ -0,0 +1,333 @@
+@@ -0,0 +1,437 @@
 +.class public final Lio/mesalabs/unica/SamsungPropsHooks;
 +.super Ljava/lang/Object;
 +.source "SamsungPropsHooks.java"
 +
 +
 +# static fields
++.field private static final blacklist CAMERA_PACKAGE_NAME:Ljava/lang/String; = "com.sec.android.app.camera"
++
 +.field private static final blacklist DEBUG:Z = false
 +
 +.field private static final blacklist FM_RADIO_PACKAGE_NAME:Ljava/lang/String; = "com.sec.android.app.fm"
@@ -132,6 +134,27 @@ index 00000000..0dd7320d
 +    sput-boolean v2, Lio/mesalabs/unica/SamsungPropsHooks;->sIsUserApp:Z
 +
 +    :goto_1
++    const-string p0, "com.sec.android.app.camera"
++
++    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result p0
++
++    if-eqz p0, :cond_2
++
++    const/16 p0, 0x23
++
++    invoke-static {p0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
++
++    move-result-object p0
++
++    const-string v0, "SEM_FIRST_SDK_INT"
++
++    invoke-static {v0, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setVersionField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto/16 :goto_2
++
++    :cond_2
 +    const-string p0, "com.sec.android.app.fm"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
@@ -140,67 +163,16 @@ index 00000000..0dd7320d
 +
 +    const-string v2, "MODEL"
 +
-+    if-eqz p0, :cond_2
++    if-eqz p0, :cond_3
 +
 +    const-string p0, "SM-A526B"
 +
-+    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
 +    goto/16 :goto_2
 +
-+    :cond_2
-+    const-string p0, "com.google.android.apps.photos"
-+
-+    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
-+
-+    move-result p0
-+
-+    if-eqz p0, :cond_3
-+
-+    const-string p0, "persist.sys.unica.gphotos"
-+
-+    invoke-static {p0, v1}, Landroid/os/SemSystemProperties;->getBoolean(Ljava/lang/String;Z)Z
-+
-+    move-result p0
-+
-+    if-eqz p0, :cond_3
-+
-+    const-string p0, "BRAND"
-+
-+    const-string v0, "google"
-+
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    const-string p0, "MANUFACTURER"
-+
-+    const-string v0, "Google"
-+
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    const-string p0, "DEVICE"
-+
-+    const-string v0, "marlin"
-+
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    const-string p0, "PRODUCT"
-+
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    const-string p0, "Pixel XL"
-+
-+    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    const-string p0, "FINGERPRINT"
-+
-+    const-string v0, "google/marlin/marlin:10/QP1A.191005.007.A3/5972272:user/release-keys"
-+
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
-+
-+    goto :goto_2
-+
 +    :cond_3
-+    const-string p0, "com.samsung.android.smartmirroring"
++    const-string p0, "com.google.android.apps.photos"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
 +
@@ -208,15 +180,66 @@ index 00000000..0dd7320d
 +
 +    if-eqz p0, :cond_4
 +
-+    const-string p0, "TYPE"
++    const-string p0, "persist.sys.unica.gphotos"
 +
-+    const-string v0, "userdebug"
++    invoke-static {p0, v1}, Landroid/os/SemSystemProperties;->getBoolean(Ljava/lang/String;Z)Z
 +
-+    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
++    move-result p0
++
++    if-eqz p0, :cond_4
++
++    const-string p0, "BRAND"
++
++    const-string v0, "google"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const-string p0, "MANUFACTURER"
++
++    const-string v0, "Google"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const-string p0, "DEVICE"
++
++    const-string v0, "marlin"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const-string p0, "PRODUCT"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const-string p0, "Pixel XL"
++
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const-string p0, "FINGERPRINT"
++
++    const-string v0, "google/marlin/marlin:10/QP1A.191005.007.A3/5972272:user/release-keys"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
 +    goto :goto_2
 +
 +    :cond_4
++    const-string p0, "com.samsung.android.smartmirroring"
++
++    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result p0
++
++    if-eqz p0, :cond_5
++
++    const-string p0, "TYPE"
++
++    const-string v0, "userdebug"
++
++    invoke-static {p0, v0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto :goto_2
++
++    :cond_5
 +    sget-object p0, Landroid/os/Build;->MODEL:Ljava/lang/String;
 +
 +    const-string v1, "SM-S901"
@@ -225,11 +248,11 @@ index 00000000..0dd7320d
 +
 +    move-result p0
 +
-+    if-eqz p0, :cond_5
++    if-eqz p0, :cond_6
 +
 +    sget-boolean p0, Lio/mesalabs/unica/SamsungPropsHooks;->sIsUserApp:Z
 +
-+    if-eqz p0, :cond_5
++    if-eqz p0, :cond_6
 +
 +    const-string p0, "com.sec"
 +
@@ -237,7 +260,7 @@ index 00000000..0dd7320d
 +
 +    move-result p0
 +
-+    if-nez p0, :cond_5
++    if-nez p0, :cond_6
 +
 +    const-string p0, "com.samsung"
 +
@@ -245,7 +268,7 @@ index 00000000..0dd7320d
 +
 +    move-result p0
 +
-+    if-nez p0, :cond_5
++    if-nez p0, :cond_6
 +
 +    const-string p0, "ro.product.odm.model"
 +
@@ -259,14 +282,14 @@ index 00000000..0dd7320d
 +
 +    move-result-object p0
 +
-+    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/String;)V
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
-+    :cond_5
++    :cond_6
 +    :goto_2
 +    return-void
 +.end method
 +
-+.method private static blacklist setBuildField(Ljava/lang/String;Ljava/lang/String;)V
++.method private static blacklist setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +    .locals 2
 +
 +    new-instance v0, Ljava/lang/StringBuilder;
@@ -285,7 +308,7 @@ index 00000000..0dd7320d
 +
 +    move-result-object v0
 +
-+    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
 +
 +    move-result-object v0
 +
@@ -320,8 +343,7 @@ index 00000000..0dd7320d
 +
 +    invoke-virtual {v0, p1}, Ljava/lang/reflect/Field;->setAccessible(Z)V
 +    :try_end_0
-+    .catch Ljava/lang/NoSuchFieldException; {:try_start_0 .. :try_end_0} :catch_0
-+    .catch Ljava/lang/IllegalAccessException; {:try_start_0 .. :try_end_0} :catch_0
++    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
 +
 +    return-void
 +
@@ -348,6 +370,88 @@ index 00000000..0dd7320d
 +
 +    return-void
 +.end method
++
++.method private static blacklist setVersionField(Ljava/lang/String;Ljava/lang/Object;)V
++    .locals 2
++
++    new-instance v0, Ljava/lang/StringBuilder;
++
++    const-string v1, "Spoofing Build.VERSION."
++
++    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
++
++    invoke-virtual {v0, p0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v0
++
++    const-string v1, " to \""
++
++    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v0
++
++    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
++
++    move-result-object v0
++
++    const-string v1, "\""
++
++    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v0
++
++    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
++
++    move-result-object v0
++
++    invoke-static {v0}, Lio/mesalabs/unica/SamsungPropsHooks;->dlog(Ljava/lang/String;)V
++
++    :try_start_0
++    const-class v0, Landroid/os/Build$VERSION;
++
++    invoke-virtual {v0, p0}, Ljava/lang/Class;->getDeclaredField(Ljava/lang/String;)Ljava/lang/reflect/Field;
++
++    move-result-object v0
++
++    const/4 v1, 0x1
++
++    invoke-virtual {v0, v1}, Ljava/lang/reflect/Field;->setAccessible(Z)V
++
++    const/4 v1, 0x0
++
++    invoke-virtual {v0, v1, p1}, Ljava/lang/reflect/Field;->set(Ljava/lang/Object;Ljava/lang/Object;)V
++
++    const/4 p1, 0x0
++
++    invoke-virtual {v0, p1}, Ljava/lang/reflect/Field;->setAccessible(Z)V
++    :try_end_0
++    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
++
++    return-void
++
++    :catch_0
++    move-exception p1
++
++    new-instance v0, Ljava/lang/StringBuilder;
++
++    const-string v1, "Failed to spoof Build.VERSION."
++
++    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
++
++    invoke-virtual {v0, p0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object p0
++
++    invoke-virtual {p0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
++
++    move-result-object p0
++
++    const-string v0, "SamsungPropsHooks"
++
++    invoke-static {v0, p0, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
++
++    return-void
++.end method
 -- 
-2.51.2
+2.54.0
 


### PR DESCRIPTION
* This enables the new exposure toggle
<img width="4320" height="904" alt="Screenshot_20260502_141843_Camera" src="https://github.com/user-attachments/assets/33948d16-40a0-4f3a-9d09-a975ec2c9e40" />

This toggle is for sure shown when sem first api is 35, but s24 (launched with 34) shows it as well. i couldn't find any other condition for this due to camera app being heavily optimized and obfuscated. 


Please do test camera for any possible broken feature. No issue was found on Galaxy A34 5G