### PR TITLE
Improvement to Build.MODEL spoof for Camera

### DIFF
--- a/platform/exynos2100/patches/camera/customize.sh
+++ b/platform/exynos2100/patches/camera/customize.sh
@@ -54,6 +54,15 @@ if [[ "$TARGET_CODENAME" == "p3s" ]]; then
 fi
 ADD_TO_WORK_DIR "$TARGET_FIRMWARE" "system" "system/lib64/libveengine.arcsoft.so" 0 0 644 "u:object_r:system_lib_file:s0"
 
+# Workaround EXIF metadata model
+# - ro.product.model > ro.boot.em.model
+HEX_PATCH "$WORK_DIR/vendor/lib/libexynoscamera3.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+HEX_PATCH "$WORK_DIR/vendor/lib64/libexynoscamera3.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+
 if [ "$TARGET_PLATFORM_SDK_VERSION" -lt "36" ]; then
     # Upgrade midas blobs
     ADD_TO_WORK_DIR "r9sxxx" "vendor" "etc/midas/midas_config.json" 0 0 644 "u:object_r:vendor_configs_file:s0"

--- a/platform/sm7325/patches/camera/customize.sh
+++ b/platform/sm7325/patches/camera/customize.sh
@@ -19,6 +19,15 @@ ADD_TO_WORK_DIR "$TARGET_FIRMWARE" "system" "system/lib64/libsaiv_HprFace_cmh_su
 ADD_TO_WORK_DIR "a73xqxx" "system" "system/lib64/libsecimaging_pdk.camera.samsung.so" 0 0 644 "u:object_r:system_lib_file:s0"
 ADD_TO_WORK_DIR "$TARGET_FIRMWARE" "system" "system/lib64/libveengine.arcsoft.so" 0 0 644 "u:object_r:system_lib_file:s0"
 
+# Workaround EXIF metadata model
+# - ro.product.model > ro.boot.em.model
+HEX_PATCH "$WORK_DIR/vendor/lib/hw/camera.qcom.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+HEX_PATCH "$WORK_DIR/vendor/lib64/hw/camera.qcom.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+
 if [ "$TARGET_PLATFORM_SDK_VERSION" -lt "36" ]; then
     # Upgrade midas blobs
     DELETE_FROM_WORK_DIR "vendor" "etc/midas"

--- a/unica/mods/settings/smali/system/framework/framework.jar/0002-Introduce-SamsungPropsHooks.patch
+++ b/unica/mods/settings/smali/system/framework/framework.jar/0002-Introduce-SamsungPropsHooks.patch
@@ -1,26 +1,104 @@
-From 0be35e0ee9fdc5078055c3cf3f10b9ab36eb2a43 Mon Sep 17 00:00:00 2001
+From 0bf49c3dc00e07c05894b442c931fc3d40d806ed Mon Sep 17 00:00:00 2001
 From: Salvo Giangreco <giangrecosalvo9@gmail.com>
 Date: Fri, 24 Oct 2025 11:59:09 +0200
 Subject: [PATCH] Introduce SamsungPropsHooks
 
 UN1CA: this patch is not complete! Please check unica/mods/settings/customize.sh for more info.
 ---
- .../io/mesalabs/unica/SamsungPropsHooks.smali | 447 ++++++++++++++++++
- 1 file changed, 447 insertions(+)
+ .../android/os/SystemProperties.smali         |  34 +-
+ .../io/mesalabs/unica/SamsungPropsHooks.smali | 580 ++++++++++++++++++
+ 2 files changed, 608 insertions(+), 6 deletions(-)
  create mode 100644 smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
 
+diff --git a/smali_classes3/android/os/SystemProperties.smali b/smali_classes3/android/os/SystemProperties.smali
+index 09f83663..7f1c0398 100644
+--- a/smali_classes3/android/os/SystemProperties.smali
++++ b/smali_classes3/android/os/SystemProperties.smali
+@@ -373,7 +373,7 @@
+ .end method
+ 
+ .method public static whitelist get(Ljava/lang/String;)Ljava/lang/String;
+-    .locals 1
++    .locals 2
+     .annotation runtime Landroid/annotation/SystemApi;
+     .end annotation
+ 
+@@ -381,18 +381,29 @@
+ 
+     move-result-object v0
+ 
+-    if-nez v0, :cond_0
++    invoke-static {p0}, Lio/mesalabs/unica/SamsungPropsHooks;->onSystemPropertiesGet(Ljava/lang/String;)Ljava/lang/String;
++
++    move-result-object v1
++
++    if-eqz v0, :cond_0
++
++    return-object v0
+ 
++    :cond_0
++    if-eqz v1, :cond_1
++
++    return-object v1
++
++    :cond_1
+     invoke-static {p0}, Landroid/os/SystemProperties;->native_get(Ljava/lang/String;)Ljava/lang/String;
+ 
+     move-result-object v0
+ 
+-    :cond_0
+     return-object v0
+ .end method
+ 
+ .method public static whitelist get(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+-    .locals 1
++    .locals 2
+     .annotation runtime Landroid/annotation/SystemApi;
+     .end annotation
+ 
+@@ -400,13 +411,24 @@
+ 
+     move-result-object v0
+ 
+-    if-nez v0, :cond_0
++    invoke-static {p0}, Lio/mesalabs/unica/SamsungPropsHooks;->onSystemPropertiesGet(Ljava/lang/String;)Ljava/lang/String;
++
++    move-result-object v1
++
++    if-eqz v0, :cond_0
++
++    return-object v0
+ 
++    :cond_0
++    if-eqz v1, :cond_1
++
++    return-object v1
++
++    :cond_1
+     invoke-static {p0, p1}, Landroid/os/SystemProperties;->native_get(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+ 
+     move-result-object v0
+ 
+-    :cond_0
+     return-object v0
+ .end method
+ 
 diff --git a/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali b/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
 new file mode 100644
-index 00000000..03068681
+index 00000000..a4dd3a99
 --- /dev/null
 +++ b/smali_classes6/io/mesalabs/unica/SamsungPropsHooks.smali
-@@ -0,0 +1,447 @@
+@@ -0,0 +1,580 @@
 +.class public final Lio/mesalabs/unica/SamsungPropsHooks;
 +.super Ljava/lang/Object;
 +.source "SamsungPropsHooks.java"
 +
 +
 +# static fields
++.field private static final blacklist AREMOJI_PACKAGE_NAME:Ljava/lang/String; = "com.samsung.android.aremoji"
++
++.field private static final blacklist CAMERAX_PACKAGE_NAME:Ljava/lang/String; = "com.samsung.android.cameraxservice"
++
 +.field private static final blacklist CAMERA_PACKAGE_NAME:Ljava/lang/String; = "com.sec.android.app.camera"
 +
 +.field private static final blacklist DEBUG:Z = false
@@ -29,6 +107,8 @@ index 00000000..03068681
 +
 +.field private static final blacklist GPHOTOS_PACKAGE_NAME:Ljava/lang/String; = "com.google.android.apps.photos"
 +
++.field private static final blacklist SINGLETAKE_PACKAGE_NAME:Ljava/lang/String; = "com.samsung.android.singletake.service"
++
 +.field private static final blacklist SMART_VIEW_PACKAGE_NAME:Ljava/lang/String; = "com.samsung.android.smartmirroring"
 +
 +.field private static final blacklist TAG:Ljava/lang/String; = "SamsungPropsHooks"
@@ -36,6 +116,8 @@ index 00000000..03068681
 +.field private static volatile blacklist sIsUserApp:Z
 +
 +.field private static volatile blacklist sPackageName:Ljava/lang/String;
++
++.field private static volatile blacklist sSpoofSingleTakeVars:Z
 +
 +
 +# direct methods
@@ -51,6 +133,24 @@ index 00000000..03068681
 +    .locals 0
 +
 +    return-void
++.end method
++
++.method private static blacklist getDeviceModel()Ljava/lang/String;
++    .locals 2
++
++    const-string v0, "ro.product.odm.model"
++
++    invoke-static {v0}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;)Ljava/lang/String;
++
++    move-result-object v0
++
++    const-string v1, "ro.boot.em.model"
++
++    invoke-static {v1, v0}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
++
++    move-result-object v0
++
++    return-object v0
 +.end method
 +
 +.method public static blacklist init(Landroid/content/Context;)V
@@ -134,44 +234,34 @@ index 00000000..03068681
 +    sput-boolean v2, Lio/mesalabs/unica/SamsungPropsHooks;->sIsUserApp:Z
 +
 +    :goto_1
-+    const-string p0, "com.sec.android.app.camera"
++    const-string p0, "com.samsung.android.singletake.service"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
 +
 +    move-result p0
 +
-+    const-string v2, "ro.product.odm.model"
++    sput-boolean p0, Lio/mesalabs/unica/SamsungPropsHooks;->sSpoofSingleTakeVars:Z
 +
-+    const-string v3, "ro.boot.em.model"
++    const-string p0, "com.samsung.android.aremoji"
 +
-+    const-string v4, "MODEL"
++    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result p0
++
++    const-string v2, "MODEL"
 +
 +    if-eqz p0, :cond_2
 +
-+    invoke-static {v2}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;)Ljava/lang/String;
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
 +
 +    move-result-object p0
 +
-+    invoke-static {v3, p0}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-+
-+    move-result-object p0
-+
-+    invoke-static {v4, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
-+
-+    const/16 p0, 0x23
-+
-+    invoke-static {p0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
-+
-+    move-result-object p0
-+
-+    const-string v0, "SEM_FIRST_SDK_INT"
-+
-+    invoke-static {v0, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setVersionField(Ljava/lang/String;Ljava/lang/Object;)V
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
 +    goto/16 :goto_2
 +
 +    :cond_2
-+    const-string p0, "com.sec.android.app.fm"
++    const-string p0, "com.samsung.android.cameraxservice"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
 +
@@ -179,14 +269,16 @@ index 00000000..03068681
 +
 +    if-eqz p0, :cond_3
 +
-+    const-string p0, "SM-A526B"
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
 +
-+    invoke-static {v4, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++    move-result-object p0
 +
-+    goto :goto_2
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto/16 :goto_2
 +
 +    :cond_3
-+    const-string p0, "com.google.android.apps.photos"
++    const-string p0, "com.sec.android.app.camera"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
 +
@@ -194,13 +286,55 @@ index 00000000..03068681
 +
 +    if-eqz p0, :cond_4
 +
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
++
++    move-result-object p0
++
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    const/16 p0, 0x23
++
++    invoke-static {p0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
++
++    move-result-object p0
++	
++    const-string v0, "SEM_FIRST_SDK_INT"
++
++    invoke-static {v0, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setVersionField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto/16 :goto_2
++
++    :cond_4
++    const-string p0, "com.sec.android.app.fm"
++
++    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result p0
++
++    if-eqz p0, :cond_5
++
++    const-string p0, "SM-A526B"
++
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto/16 :goto_2
++
++    :cond_5
++    const-string p0, "com.google.android.apps.photos"
++
++    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result p0
++
++    if-eqz p0, :cond_6
++
 +    const-string p0, "persist.sys.unica.gphotos"
 +
 +    invoke-static {p0, v1}, Landroid/os/SemSystemProperties;->getBoolean(Ljava/lang/String;Z)Z
 +
 +    move-result p0
 +
-+    if-eqz p0, :cond_4
++    if-eqz p0, :cond_6
 +
 +    const-string p0, "BRAND"
 +
@@ -226,7 +360,7 @@ index 00000000..03068681
 +
 +    const-string p0, "Pixel XL"
 +
-+    invoke-static {v4, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
 +    const-string p0, "FINGERPRINT"
 +
@@ -236,14 +370,27 @@ index 00000000..03068681
 +
 +    goto :goto_2
 +
-+    :cond_4
++    :cond_6
++    sget-boolean p0, Lio/mesalabs/unica/SamsungPropsHooks;->sSpoofSingleTakeVars:Z
++
++    if-eqz p0, :cond_7
++
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
++
++    move-result-object p0
++
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++
++    goto :goto_2
++
++    :cond_7
 +    const-string p0, "com.samsung.android.smartmirroring"
 +
 +    invoke-virtual {v0, p0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
 +
 +    move-result p0
 +
-+    if-eqz p0, :cond_5
++    if-eqz p0, :cond_8
 +
 +    const-string p0, "TYPE"
 +
@@ -253,7 +400,7 @@ index 00000000..03068681
 +
 +    goto :goto_2
 +
-+    :cond_5
++    :cond_8
 +    sget-object p0, Landroid/os/Build;->MODEL:Ljava/lang/String;
 +
 +    const-string v1, "SM-S901"
@@ -262,11 +409,11 @@ index 00000000..03068681
 +
 +    move-result p0
 +
-+    if-eqz p0, :cond_6
++    if-eqz p0, :cond_9
 +
 +    sget-boolean p0, Lio/mesalabs/unica/SamsungPropsHooks;->sIsUserApp:Z
 +
-+    if-eqz p0, :cond_6
++    if-eqz p0, :cond_9
 +
 +    const-string p0, "com.sec"
 +
@@ -274,7 +421,7 @@ index 00000000..03068681
 +
 +    move-result p0
 +
-+    if-nez p0, :cond_6
++    if-nez p0, :cond_9
 +
 +    const-string p0, "com.samsung"
 +
@@ -282,21 +429,81 @@ index 00000000..03068681
 +
 +    move-result p0
 +
-+    if-nez p0, :cond_6
++    if-nez p0, :cond_9
 +
-+    invoke-static {v2}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;)Ljava/lang/String;
-+
-+    move-result-object p0
-+
-+    invoke-static {v3, p0}, Landroid/os/SemSystemProperties;->get(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
 +
 +    move-result-object p0
 +
-+    invoke-static {v4, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
++    invoke-static {v2, p0}, Lio/mesalabs/unica/SamsungPropsHooks;->setBuildField(Ljava/lang/String;Ljava/lang/Object;)V
 +
-+    :cond_6
++    :cond_9
 +    :goto_2
 +    return-void
++.end method
++
++.method public static blacklist onSystemPropertiesGet(Ljava/lang/String;)Ljava/lang/String;
++    .locals 3
++
++    const/4 v0, 0x0
++
++    const-string v1, "ro.product.model"
++
++    invoke-virtual {p0, v1}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
++
++    move-result v1
++
++    if-eqz v1, :cond_0
++
++    sget-boolean v1, Lio/mesalabs/unica/SamsungPropsHooks;->sSpoofSingleTakeVars:Z
++
++    if-eqz v1, :cond_0
++
++    invoke-static {}, Lio/mesalabs/unica/SamsungPropsHooks;->getDeviceModel()Ljava/lang/String;
++
++    move-result-object v0
++
++    :cond_0
++    if-eqz v0, :cond_1
++
++    new-instance v1, Ljava/lang/StringBuilder;
++
++    invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
++
++    const-string v2, "Spoofing \""
++
++    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v1
++
++    invoke-virtual {v1, p0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v1
++
++    const-string v2, "\" prop to \""
++
++    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v1
++
++    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v1
++
++    const-string v2, "\""
++
++    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
++
++    move-result-object v1
++
++    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
++
++    move-result-object v1
++
++    invoke-static {v1}, Lio/mesalabs/unica/SamsungPropsHooks;->dlog(Ljava/lang/String;)V
++
++    :cond_1
++    return-object v0
 +.end method
 +
 +.method private static blacklist setBuildField(Ljava/lang/String;Ljava/lang/Object;)V

--- a/unica/patches/camera/customize.sh
+++ b/unica/patches/camera/customize.sh
@@ -361,6 +361,15 @@ if [ ! "$(find "$WORK_DIR/product/overlay" -maxdepth 1 -type f -name "SystemUI*"
     fi
 fi
 
+# Workaround video metadata model
+# - ro.product.model > ro.boot.em.model
+HEX_PATCH "$WORK_DIR/system/system/lib/libstagefright.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+HEX_PATCH "$WORK_DIR/system/system/lib64/libstagefright.so" \
+    "726f2e70726f647563742e6d6f64656c" \
+    "726f2e626f6f742e656d2e6d6f64656c"
+
 unset SOURCE_FIRMWARE_PATH TARGET_FIRMWARE_PATH \
     SOURCE_CAMERA_CONFIG_ACTION_CLASSIFIER TARGET_CAMERA_CONFIG_ACTION_CLASSIFIER \
     SOURCE_CAMERA_CONFIG_GPPM_SOLUTIONS TARGET_CAMERA_CONFIG_GPPM_SOLUTIONS \


### PR DESCRIPTION
Switch to ro.boot.em.model instead of ro.product.model to match model metadata tag with stock
Spoof Build.MODEL to more camera related apps, including AR Emoji, CameraX Service and Single Take