### PR TITLE
unica: mods: settings: centralize SearchIndexableData registrations

### DIFF
--- a/unica/mods/settings/SecSettings.apk/smali_classes4/io/mesalabs/unica/search/UnicaSearchIndexableResources.smali
+++ b/unica/mods/settings/SecSettings.apk/smali_classes4/io/mesalabs/unica/search/UnicaSearchIndexableResources.smali
@@ -1,0 +1,53 @@
+.class public final Lio/mesalabs/unica/search/UnicaSearchIndexableResources;
+.super Lcom/android/settingslib/search/SearchIndexableResourcesMobile;
+.source "UnicaSearchIndexableResources.java"
+
+
+# direct methods
+.method public constructor <init>()V
+    .locals 3
+
+    invoke-direct {p0}, Lcom/android/settingslib/search/SearchIndexableResourcesMobile;-><init>()V
+
+    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;
+
+    const-class v1, Lio/mesalabs/unica/settings/UnicaSettingsFragment;
+
+    sget-object v2, Lio/mesalabs/unica/settings/UnicaSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;
+
+    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V
+
+    invoke-virtual {p0, v0}, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V
+
+    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;
+
+    const-class v1, Lio/mesalabs/unica/settings/extra/ExtraSettingsFragment;
+
+    sget-object v2, Lio/mesalabs/unica/settings/extra/ExtraSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;
+
+    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V
+
+    invoke-virtual {p0, v0}, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V
+
+    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;
+
+    const-class v1, Lio/mesalabs/unica/settings/spoof/SpoofSettingsFragment;
+
+    sget-object v2, Lio/mesalabs/unica/settings/spoof/SpoofSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;
+
+    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V
+
+    invoke-virtual {p0, v0}, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V
+
+    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;
+
+    const-class v1, Lio/mesalabs/unica/settings/ui/UISettingsFragment;
+
+    sget-object v2, Lio/mesalabs/unica/settings/ui/UISettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;
+
+    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V
+
+    invoke-virtual {p0, v0}, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V
+
+    return-void
+.end method

--- a/unica/mods/settings/customize.sh
+++ b/unica/mods/settings/customize.sh
@@ -69,132 +69,27 @@ while IFS= read -r f; do
     fi
 done < <(find "$MODPATH/SecSettings.apk" -type f)
 
-# Add UN1CA Settings SearchIndexDataProvider(s)
-LOG "- Patching \"smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali\" in /system/system/priv-app/SecSettings.apk"
+# Add UN1CA Settings SearchIndexableData registrations
+LOG "- Patching \"smali/com/android/settingslib/search/SearchIndexableResourcesMobile.smali\" in /system/system/priv-app/SecSettings.apk"
 SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;\n\n    return-void' \
+    "smali/com/android/settingslib/search/SearchIndexableResourcesMobile.smali" "replaceall" \
+    '.class public final Lcom/android/settingslib/search/SearchIndexableResourcesMobile;' \
+    '.class public Lcom/android/settingslib/search/SearchIndexableResourcesMobile;' \
+    > /dev/null
+LOG "- Patching \"smali/com/android/settings/search/SearchFeatureProviderImpl\$\$ExternalSyntheticLambda0.smali\" in /system/system/priv-app/SecSettings.apk"
+SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
+    "smali/com/android/settings/search/SearchFeatureProviderImpl\$\$ExternalSyntheticLambda0.smali" "replace" \
+    'invoke()Ljava/lang/Object;' \
+    'new-instance p0, Lcom/android/settingslib/search/SearchIndexableResourcesMobile;' \
+    'new-instance p0, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;' \
     > /dev/null
 SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    const-class v1, Lio/mesalabs/unica/settings/UnicaSettingsFragment;\n\n    return-void' \
+    "smali/com/android/settings/search/SearchFeatureProviderImpl\$\$ExternalSyntheticLambda0.smali" "replace" \
+    'invoke()Ljava/lang/Object;' \
+    'invoke-direct {p0}, Lcom/android/settingslib/search/SearchIndexableResourcesBase;-><init>()V' \
+    'invoke-direct {p0}, Lio/mesalabs/unica/search/UnicaSearchIndexableResources;-><init>()V' \
     > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    sget-object v2, Lio/mesalabs/unica/settings/UnicaSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;\n\n    return-void' \
-    > /dev/null
-# shellcheck disable=SC2016
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-virtual {p0, v0}, Lcom/android/settingslib/search/SearchIndexableResourcesBase;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    const-class v1, Lio/mesalabs/unica/settings/extra/ExtraSettingsFragment;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    sget-object v2, Lio/mesalabs/unica/settings/extra/ExtraSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;\n\n    return-void' \
-    > /dev/null
-# shellcheck disable=SC2016
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-virtual {p0, v0}, Lcom/android/settingslib/search/SearchIndexableResourcesBase;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    const-class v1, Lio/mesalabs/unica/settings/spoof/SpoofSettingsFragment;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    sget-object v2, Lio/mesalabs/unica/settings/spoof/SpoofSettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;\n\n    return-void' \
-    > /dev/null
-# shellcheck disable=SC2016
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-virtual {p0, v0}, Lcom/android/settingslib/search/SearchIndexableResourcesBase;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    new-instance v0, Lcom/android/settingslib/search/SearchIndexableData;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    const-class v1, Lio/mesalabs/unica/settings/ui/UISettingsFragment;\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    sget-object v2, Lio/mesalabs/unica/settings/ui/UISettingsFragment;->SEARCH_INDEX_DATA_PROVIDER:Lcom/android/settings/search/BaseSearchIndexProvider;\n\n    return-void' \
-    > /dev/null
-# shellcheck disable=SC2016
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-direct {v0, v1, v2}, Lcom/android/settingslib/search/SearchIndexableData;-><init>(Ljava/lang/Class;Lcom/android/settingslib/search/Indexable$SearchIndexProvider;)V\n\n    return-void' \
-    > /dev/null
-SMALI_PATCH "system" "system/priv-app/SecSettings/SecSettings.apk" \
-    "smali/com/android/settingslib/search/SearchIndexableResourcesBase.smali" "replace" \
-    '<init>()V' \
-    'return-void' \
-    '    invoke-virtual {p0, v0}, Lcom/android/settingslib/search/SearchIndexableResourcesBase;->addIndex(Lcom/android/settingslib/search/SearchIndexableData;)V\n\n    return-void' \
-    > /dev/null
+
 DECODE_APK "system" "system/priv-app/SecSettingsIntelligence/SecSettingsIntelligence.apk"
 LOG "- Patching \"smali_classes2/com/samsung/android/settings/intelligence/search/categorizing/TopLevelKeysCollector.smali\" in /system/system/priv-app/SecSettingsIntelligence/SecSettingsIntelligence.apk"
 SMALI_PATCH "system" "system/priv-app/SecSettingsIntelligence/SecSettingsIntelligence.apk" \


### PR DESCRIPTION
### Description
Centralizes UN1CA Settings `SearchIndexableData` registrations into a dedicated class instead of building up the method bytecode line by line via `SMALI_PATCH`.

### Motivation
The previous approach inserted each `addIndex` call into `SearchIndexableResourcesBase.<init>` by repeatedly replacing `return-void` with the next bytecode line plus a new `return-void`. That's 5 patches per fragment, 20 in total for 4 fragments, and adding a new one meant copying another full block into `customize.sh`. This PR moves the registration to a dedicated class, keeping the script clean and the intent obvious.

### Changes
- **Introduced `UnicaSearchIndexableResources`**: extends `SearchIndexableResourcesMobile` and registers all UN1CA `SearchIndexableData` entries in its constructor.
- **Patched `SearchIndexableResourcesMobile`**: removed `final` to allow subclassing.
- **Patched `SearchFeatureProviderImpl$$ExternalSyntheticLambda0`**: redirected instantiation to `UnicaSearchIndexableResources`.
- **Cleanup**: ~100 lines of sequential `SMALI_PATCH` calls replaced with 3 targeted patches.

### Relevant class hierarchy
_`super()` calls are shown explicitly for clarity_
```java
/* JADX INFO: loaded from: classes.dex */
public interface SearchIndexableResources {
}
```
```java
/* JADX INFO: loaded from: classes.dex */
public abstract class SearchIndexableResourcesBase implements SearchIndexableResources {
    public final Set mProviders = new HashSet();

    public SearchIndexableResourcesBase() {
    	super();
        addIndex(new SearchIndexableData(AccountDashboardFragment.class, AccountDashboardFragment.SEARCH_INDEX_DATA_PROVIDER));
        addIndex(new SearchIndexableData(ManagedProfileSettings.class, ManagedProfileSettings.SEARCH_INDEX_DATA_PROVIDER));
        // ...
    }

    public final void addIndex(SearchIndexableData searchIndexableData) {
        ((HashSet) this.mProviders).add(searchIndexableData);
    }
}
```
```java
/* JADX INFO: loaded from: classes.dex */
public class SearchIndexableResourcesMobile extends SearchIndexableResourcesBase {
	public SearchIndexableResourcesMobile() {
    	super();
	}
}
```
```java
public final class UnicaSearchIndexableResources extends SearchIndexableResourcesMobile {
    public UnicaSearchIndexableResources() {
    	super();
        addIndex(new SearchIndexableData(UnicaSettingsFragment.class, UnicaSettingsFragment.SEARCH_INDEX_DATA_PROVIDER));
        addIndex(new SearchIndexableData(ExtraSettingsFragment.class, ExtraSettingsFragment.SEARCH_INDEX_DATA_PROVIDER));
        addIndex(new SearchIndexableData(SpoofSettingsFragment.class, SpoofSettingsFragment.SEARCH_INDEX_DATA_PROVIDER));
        addIndex(new SearchIndexableData(UISettingsFragment.class, UISettingsFragment.SEARCH_INDEX_DATA_PROVIDER));
    }
}
```

The lambda that builds the full provider set:

```java
/* JADX INFO: loaded from: classes.dex */
public final class SearchFeatureProviderImpl$$ExternalSyntheticLambda0 implements Function0 {
    @Override
    public final Object invoke() {
        // Patched from "new SearchIndexableResourcesMobile()"
        UnicaSearchIndexableResources unicaSearchIndexableResources = new UnicaSearchIndexableResources();
        unicaSearchIndexableResources.addIndex(new SearchIndexableData(DisplaySettings.class, DisplaySettings.SEARCH_INDEX_DATA_PROVIDER));
        unicaSearchIndexableResources.addIndex(new SearchIndexableData(AccessibilityAudioRoutingFragment.class, AccessibilityAudioRoutingFragment.SEARCH_INDEX_DATA_PROVIDER));
        // ...
        return unicaSearchIndexableResources;
    }
}
```
> [!NOTE]
> Suggestions on the `customize.sh` side are welcome.