### PR TITLE
exynos2100: workaround for vulkan glitches

### DIFF
--- a/platform/exynos2100/patches/vulkan/customize.sh
+++ b/platform/exynos2100/patches/vulkan/customize.sh
@@ -1,0 +1,7 @@
+LOG "- Patching SBWC compression for Vulkan compatibility in /vendor/build.prop"
+
+EVAL "if grep -q '^vendor.debug.c2.sbwc.enable=' \"$WORK_DIR/vendor/build.prop\"; then \
+        sed -i 's/^vendor.debug.c2.sbwc.enable=.*/vendor.debug.c2.sbwc.enable=false/g' \"$WORK_DIR/vendor/build.prop\"; \
+      else \
+        echo 'vendor.debug.c2.sbwc.enable=false' >> \"$WORK_DIR/vendor/build.prop\"; \
+      fi"

--- a/platform/exynos2100/patches/vulkan/module.prop
+++ b/platform/exynos2100/patches/vulkan/module.prop
@@ -1,0 +1,4 @@
+id=vulkan
+name=Vulkan render fix
+author=elitetest1
+description= workaround for vulkan glitches.


### PR DESCRIPTION
This patch resolves the long-standing buffer starvation loop by disabling SBWC compression in the c2 decoder, preventing Vulkan's SkiaVK from choking on proprietary samsung formats.